### PR TITLE
perf: fix media proxy race condition, optimize cache eviction, cache themes, improve SSE reconnect

### DIFF
--- a/src/themes/default.ts
+++ b/src/themes/default.ts
@@ -146,11 +146,8 @@ export const defaultTheme = `<!DOCTYPE html>
 
       eventSource.addEventListener('ping', () => {});
 
-      eventSource.onerror = () => {
-        console.log('SSE connection lost, reconnecting...');
-        eventSource.close();
-        setTimeout(connectSSE, 2000);
-      };
+      // Reconnection is handled natively by EventSource using the
+      // server-sent retry: hint — no manual reconnect needed.
     }
 
     fetch('/api/now-playing')


### PR DESCRIPTION
## What

Fixes 5 optimization/reliability issues identified in #4.

## Changes

### 1. Fix race condition in `mediaDetector` proxy (`src/core/media.ts`)

The `on()` method was called at module top-level in `server/index.ts`, but if the instance wasn't ready yet, listeners were attached asynchronously via `getInstance().then(...)`. This meant `start()` could emit events before listeners were actually registered.

**Fix:** Listeners registered before initialization are queued in a `pendingListeners` array and flushed synchronously once the instance resolves. The initialization promise is also deduped to avoid multiple `getMediaDetector()` calls.

### 2. Add bounded cache with O(n) eviction (`src/core/media/cover-fallback.ts`)

The cover art cache had no size limit on `main`. Added a `CACHE_MAX_SIZE = 200` cap with O(n) linear scan to find the oldest entry (instead of an O(n log n) sort).

### 3. Cache theme files in memory (`src/server/index.ts`)

`/now-playing` was calling `readFileSync` on every request for custom themes. Now caches file content in memory, keyed by path, and invalidates when `mtime` changes.

### 4. SSE `retry:` hint (`src/server/index.ts` + `src/themes/default.ts`)

The SSE stream now sends `retry: 2000` on connection. This lets `EventSource` handle reconnection natively, so the manual `setTimeout(connectSSE, 2000)` in the default theme is no longer needed.

### 5. Remove redundant port check (`src/server/index.ts`)

The old `checkPortAvailable()` spun up a full `Bun.serve()` instance just to test port availability, then immediately stopped it. Now we just let the actual `Bun.serve()` call fail and catch `EADDRINUSE` directly.

## Testing

- Code reviewed for correctness
- No breaking changes to the public API
- All changes are backward-compatible

Closes #4