### PR TITLE
improve: Linux Deezer cover fallback + CI darwin-x64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
             os: macos-latest
             target: bun-darwin-arm64
             artifact: orpheus-darwin-arm64
+          - name: darwin-x64
+            os: macos-13
+            target: bun-darwin-x64
+            artifact: orpheus-darwin-x64
           - name: linux-x64
             os: ubuntu-latest
             target: bun-linux-x64


### PR DESCRIPTION
## Context

Extracted from the now-closed #3 — only the changes that are still relevant after #5 was merged.

## Changes

### 1. Linux: Deezer cover art fallback

When `playerctl` doesn't provide artwork (common with web-based players via MPRIS), the overlay showed an empty grey square.

Now uses the same Deezer API fallback that macOS and Windows already have:
- New `resolveArtwork()` method centralizes artwork resolution (file:// → http(s):// → Deezer fallback)
- Deduplicates file:// loading logic that was copy-pasted between `processPlayerctlOutput` and `getNowPlaying`
- Falls back to `fetchCoverArt()` from `cover-fallback.ts` when no local artwork is available

### 2. CI: darwin-x64 build target

Adds macOS Intel (x64) to the release matrix. Uses `macos-13` runner (last Intel macOS runner available on GitHub Actions).

## What was dropped from #3

The following changes from #3 were already merged via #5 or are no longer needed:
- Media proxy race condition fix → in #5
- Cache eviction optimization → in #5
- Theme file caching → in #5
- SSE retry hint → in #5
- Port check removal → in #5

Supersedes #3.