### PR TITLE
fix(ci): use macos-latest for darwin-x64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             target: bun-darwin-arm64
             artifact: orpheus-darwin-arm64
           - name: darwin-x64
-            os: macos-13
+            os: macos-latest
             target: bun-darwin-x64
             artifact: orpheus-darwin-x64
           - name: linux-x64


### PR DESCRIPTION
## Problem

`macos-13` runners have been removed from GitHub Actions, causing the darwin-x64 build to fail:

```
The configuration 'macos-13-us-default' is not supported
```

## Fix

Switch to `macos-latest` (ARM). Bun supports cross-compilation via `--target=bun-darwin-x64`, so we can build the x64 binary from an ARM runner — same approach already used for `linux-arm64` (built from an x64 ubuntu runner).

One-line change: `macos-13` → `macos-latest`.