### PR TITLE
fix: replace Bun shell commands with cross-platform Node.js APIs

### DIFF
--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
-import { $ } from "bun";
-import { existsSync, mkdirSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
+import { execSync } from "child_process";
 import { getThemesDir, loadConfig, saveConfig } from "../../core/config";
 import { ui } from "../ui";
 
@@ -50,7 +50,7 @@ export const addCommand = defineCommand({
     ui.spinner(`Installing ${ui.primary(themeName)}...`);
 
     try {
-      await $`git clone --depth 1 ${repoUrl} ${themeDir}`.quiet();
+      execSync(`git clone --depth 1 ${repoUrl} "${themeDir}"`, { stdio: "ignore" });
     } catch {
       ui.log.error(`Failed to clone: ${repoUrl}`);
       ui.log.info("Make sure the repository exists and is public");
@@ -60,7 +60,7 @@ export const addCommand = defineCommand({
     const themeHtml = join(themeDir, "theme.html");
     if (!existsSync(themeHtml)) {
       ui.log.error("Invalid theme: theme.html not found");
-      await $`rm -rf ${themeDir}`.quiet();
+      rmSync(themeDir, { recursive: true, force: true });
       process.exit(1);
     }
 
@@ -81,7 +81,7 @@ export const addCommand = defineCommand({
       }
     }
 
-    await $`rm -rf ${join(themeDir, ".git")}`.quiet();
+    rmSync(join(themeDir, ".git"), { recursive: true, force: true });
 
     const config = loadConfig();
     config.themes[themeName] = {

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from "citty";
-import { $ } from "bun";
-import { existsSync, readdirSync, rmdirSync } from "fs";
+import { existsSync, readdirSync, rmdirSync, rmSync } from "fs";
 import { join, dirname } from "path";
 import { getThemesDir, loadConfig, saveConfig } from "../../core/config";
 import { ui } from "../ui";
@@ -48,7 +47,7 @@ export const removeCommand = defineCommand({
     ui.spinner(`Removing ${themeName}...`);
 
     try {
-      await $`rm -rf ${themeDir}`.quiet();
+      rmSync(themeDir, { recursive: true, force: true });
     } catch (error) {
       ui.log.error(`Failed: ${(error as Error).message}`);
       process.exit(1);

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,9 +1,9 @@
 import { defineCommand } from "citty";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { $ } from "bun";
-import { existsSync, mkdirSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
+import { execSync } from "child_process";
 import { getThemesDir, loadConfig, saveConfig } from "../../core/config";
 
 const REGISTRY_URL = "https://raw.githubusercontent.com/Collectif-Pixel/orpheus-themes/main/registry.json";
@@ -107,7 +107,7 @@ export const searchCommand = defineCommand({
       s.start(action === "install" ? "Installing..." : "Updating...");
 
       if (existsSync(themeDir)) {
-        await $`rm -rf ${themeDir}`.quiet();
+        rmSync(themeDir, { recursive: true, force: true });
       }
 
       if (!existsSync(scopeDir)) {
@@ -117,8 +117,8 @@ export const searchCommand = defineCommand({
       const repoUrl = `https://github.com/${scope}/${name}.git`;
 
       try {
-        await $`git clone --depth 1 ${repoUrl} ${themeDir}`.quiet();
-        await $`rm -rf ${join(themeDir, ".git")}`.quiet();
+        execSync(`git clone --depth 1 ${repoUrl} "${themeDir}"`, { stdio: "ignore" });
+        rmSync(join(themeDir, ".git"), { recursive: true, force: true });
 
         let version = "unknown";
         const packageJsonPath = join(themeDir, "package.json");
@@ -167,7 +167,7 @@ export const searchCommand = defineCommand({
       s.start("Removing...");
 
       try {
-        await $`rm -rf ${themeDir}`.quiet();
+        rmSync(themeDir, { recursive: true, force: true });
         delete config.themes[selectedTheme.name];
 
         if (config.currentTheme === selectedTheme.name) {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "citty";
-import { spawn, $ } from "bun";
+import { spawn } from "bun";
+import { appendFileSync } from "fs";
 import { startServer } from "../../server";
 import { loadConfig, ensureConfigDir } from "../../core/config";
 import { isDaemonRunning, writePid, getLogFilePath } from "../../core/daemon";
@@ -104,7 +105,7 @@ export const startCommand = defineCommand({
             stdin: "ignore",
           });
 
-          await $`echo "=== Orpheus started at $(date) ===" >> ${logPath}`.quiet();
+          appendFileSync(logPath, `=== Orpheus started at ${new Date().toISOString()} ===\n`);
           await new Promise((resolve) => setTimeout(resolve, DAEMON_START_DELAY_MS));
 
           if (child.exitCode !== null) {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
-import { $ } from "bun";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
+import { execSync } from "child_process";
 import { getThemesDir, loadConfig, saveConfig } from "../../core/config";
 import { ui } from "../ui";
 
@@ -69,8 +69,8 @@ async function updateTheme(themeName: string, config: ReturnType<typeof loadConf
   const repoUrl = `https://github.com/${scope}/${name}.git`;
 
   try {
-    await $`rm -rf ${themeDir}`.quiet();
-    await $`git clone --depth 1 ${repoUrl} ${themeDir}`.quiet();
+    rmSync(themeDir, { recursive: true, force: true });
+    execSync(`git clone --depth 1 ${repoUrl} "${themeDir}"`, { stdio: "ignore" });
   } catch {
     ui.log.error(`Failed to update ${themeName}`);
     return;
@@ -79,7 +79,7 @@ async function updateTheme(themeName: string, config: ReturnType<typeof loadConf
   const themeHtml = join(themeDir, "theme.html");
   if (!existsSync(themeHtml)) {
     ui.log.error(`Invalid theme: theme.html not found`);
-    await $`rm -rf ${themeDir}`.quiet();
+    rmSync(themeDir, { recursive: true, force: true });
     return;
   }
 
@@ -92,7 +92,7 @@ async function updateTheme(themeName: string, config: ReturnType<typeof loadConf
     } catch {}
   }
 
-  await $`rm -rf ${join(themeDir, ".git")}`.quiet();
+  rmSync(join(themeDir, ".git"), { recursive: true, force: true });
 
   config.themes[themeName] = {
     repo: `github:${scope}/${name}`,


### PR DESCRIPTION
## Problem

Theme installation fails on Windows (CMD/PowerShell) because the code uses `rm -rf` via Bun's `$\`` shell, which delegates to the system shell. On Windows, `rm -rf` is not a recognized command.

Reported in #8.

## Solution

Replace all Bun shell (`$ \`...\``) usage with cross-platform Node.js APIs:

- **`rm -rf`** → `rmSync(path, { recursive: true, force: true })` from `fs`
- **`git clone`** → `execSync('git clone ...')` from `child_process`
- **`echo >> file`** → `appendFileSync()` from `fs`

## Files changed

- `src/cli/commands/search.ts` — theme install/update/remove via search UI
- `src/cli/commands/add.ts` — `orpheus add` command
- `src/cli/commands/remove.ts` — `orpheus remove` command
- `src/cli/commands/update.ts` — `orpheus update` command
- `src/cli/commands/start.ts` — daemon start log

## Testing

- Tested on Linux (should now also work on Windows CMD/PowerShell/Git Bash)
- All `import { $ } from 'bun'` removed from affected files

Fixes #8